### PR TITLE
Revert previous commit using a code change and replace it with a ruleset priority override.

### DIFF
--- a/Loadsys/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Loadsys/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -115,7 +115,7 @@ class Loadsys_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSn
 			}
 		} elseif ($private === true) {
 			if (substr($varName, 0, 2) !== '__') {
-				$error = 'Private member variable "%s" must contain a leading underscore';
+				$error = 'Private member variable "%s" must contain two leading underscores';
 				$data = array($varName);
 				$phpcsFile->addError($error, $stackPtr, 'PrivateNoUnderscore', $data);
 				return;
@@ -127,12 +127,12 @@ class Loadsys_Sniffs_NamingConventions_ValidVariableNameSniff extends PHP_CodeSn
 				$phpcsFile->addWarning($warning, $stackPtr, 'PrivateInCore', $data);
 			}
 		} else {  // protected var
-// 			if (substr($varName, 0, 1) !== '_') {
-// 				$error = 'Protected member variable "%s" must contain a leading underscore';
-// 				$data = array($varName);
-// 				$phpcsFile->addError($error, $stackPtr, 'ProtectedNoUnderscore', $data);
-// 				return;
-// 			}
+			if (substr($varName, 0, 1) !== '_') {
+				$error = 'Protected member variable "%s" must contain a leading underscore';
+				$data = array($varName);
+				$phpcsFile->addError($error, $stackPtr, 'ProtectedNoUnderscore', $data);
+				return;
+			}
 		}
 
 		$conditions = array_keys($tokens[$stackPtr]['conditions']);

--- a/Loadsys/ruleset.xml
+++ b/Loadsys/ruleset.xml
@@ -65,4 +65,16 @@
  <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
 
  <!-- All rules in ./Sniffs are included automatically -->
+
+  <!--
+    However, we can still include sniffs and essentially ignore them
+    as "errors" by setting their severity here.
+  -->
+  <rule ref="Loadsys.NamingConventions.ValidFunctionName.PublicWithUnderscore">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Loadsys.NamingConventions.ValidFunctionName.ProtectedNoUnderscore">
+    <severity>0</severity>
+  </rule>
+
 </ruleset>


### PR DESCRIPTION
It's largely unnecessary to change the PHP code for the sniffs themselves. Instead, the reported severity of any given sniff can be modified in the ruleset.xml file for the defined code standard.

This PR uses that approach to nullify detection of public methods that start with underscores (which Loadsys typically uses for `__auth()` controller methods) as well as not requiring underscores for protected methods (which doesn't always provide any additional clarity.)
