### PR TITLE
Add additional suppression for backwards compatibility.

### DIFF
--- a/Loadsys/ruleset.xml
+++ b/Loadsys/ruleset.xml
@@ -95,4 +95,18 @@
     <severity>0</severity>
   </rule>
 
+  <rule ref="Loadsys.NamingConventions.ValidPrivateProtectedFunctionName.PrivateWithUnderscore">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Loadsys.NamingConventions.ValidPrivateProtectedFunctionName.ProtectedWithUnderscore">
+    <severity>0</severity>
+  </rule>
+
+  <rule ref="Loadsys.NamingConventions.ValidPrivateProtectedVariableName.PrivateWithUnderscore">
+    <severity>0</severity>
+  </rule>
+  <rule ref="Loadsys.NamingConventions.ValidPrivateProtectedVariableName.ProtectedUnderscore">
+    <severity>0</severity>
+  </rule>
+
 </ruleset>

--- a/tests/files/Loadsys/for_function_naming_fail.php
+++ b/tests/files/Loadsys/for_function_naming_fail.php
@@ -11,21 +11,29 @@ class Foo {
 	}
 
 	/**
-	 * [doSomethingPrivate description]
+	 * This method name _should_ trigger an error due to the leading
+	 * underscore being banned, but that error is suppressed
+	 * in the ruleset.xml for backwards compatibility with many Loadsys
+	 * projects. So we make this fail "artificially" by adding an
+	 * extra trailing underscore.
 	 *
 	 * @param string $foo Foo
 	 * @return void
 	 */
-	protected function _doSomethingProtected($foo) {
+	protected function _doSomethingProtected_($foo) {
 	}
 
 	/**
-	 * [doSomethingPrivate description]
+	 * This method name _should_ trigger an error due to the leading
+	 * double-underscores being banned, but that error is suppressed
+	 * in the ruleset.xml for backwards compatibility with many Loadsys
+	 * projects. So we make this fail "artificially" by adding an
+	 * extra trailing underscore.
 	 *
 	 * @param string $foo Foo
 	 * @return void
 	 */
-	private function __doSomethingPrivate($foo) {
+	private function __doSomethingPrivate_($foo) {
 	}
 
 }


### PR DESCRIPTION
Many of our projects still have functions like `public AppController:_auth()`, which break the "normal" rules. These could be changed to comply more strictly with the code standards, but in cases like this the underscore helps emphasize that the controller method isn't meant to be handled by a URL route.

Closes #15. After tagging for `1.0.1`, will also close loadsys/Fairmount#200.