### PR TITLE
Drops Support for PHP 5.3 In Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
 
 before_script:


### PR DESCRIPTION
Cake 3.x doesn't support PHP 5.3 so no reason for this to test on PHP 5.3
