### PR TITLE
Add a missing warning, disable a duplicate from the CakePHP set.

### DIFF
--- a/Loadsys/ruleset.xml
+++ b/Loadsys/ruleset.xml
@@ -15,6 +15,8 @@
 		<!-- Disable enforcing leading underscores for protected/private methods. -->
 		<exclude name="Squiz.NamingConventions.ValidFunctionName.PrivateNoUnderscore"/>
 		<exclude name="PEAR.NamingConventions.ValidFunctionName.PrivateNoUnderscore"/>
+		<!-- Disable enforcing no leading underscores for public methods (we have our own). -->
+		<exclude name="CakePHP.NamingConventions.ValidFunctionName.PublicWithUnderscore"/>
 
 		<!-- Disable enforcing spaces for indenting. -->
 		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
@@ -56,10 +58,14 @@
 	</rule>
 
 	<!--
-	Make using underscores in private and protected variable names a
+	Make using underscores in private and protected class method names a
 	warning (that can then be suppressed) for compatibility with Entity
 	classes that require this.
 	-->
+	<rule ref="Loadsys.NamingConventions.ValidPrivateProtectedFunctionName.PublicWithUnderscore">
+		<type>warning</type>
+	</rule>
+
 	<rule ref="Loadsys.NamingConventions.ValidPrivateProtectedFunctionName.ProtectedWithUnderscore">
 		<type>warning</type>
 	</rule>


### PR DESCRIPTION
This should allow the ConfigReadShell tests to pass by converting `Loadsys.NamingConventions.ValidPrivateProtectedFunctionName.PublicWithUnderscore` into a WARNING: 

```
FILE: src/Shell/ConfigReadShell.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 82 | WARNING | Public method name "ConfigReadShell::_welcome" must not
    |         | be prefixed with underscore
    |         | (Loadsys.NamingConventions.ValidPrivateProtectedFunctionName.PublicWithUnderscore)
----------------------------------------------------------------------
```