### PR TITLE
F/composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "loadsys/loadsys_codesniffer",
   "description": "Loadsys CodeSniffer Standards, uses the CakePHP core team's as a base.",
-  "type": "library",
+  "type": "phpcs-coding-standard",
   "keywords": ["framework", "codesniffer"],
   "homepage": "https://github.com/loadsys/loadsys_codesniffer",
   "support": {
@@ -9,11 +9,12 @@
       "source": "https://github.com/loadsys/loadsys_codesniffer"
   },
   "require": {
-      "squizlabs/php_codesniffer": "2.*",
-      "cakephp/cakephp-codesniffer": "^2.0.4"
+      "squizlabs/php_codesniffer": "~2.3",
+      "cakephp/cakephp-codesniffer": "^2.0.4",
+      "loadsys/composer-plugins": "dev-f/phpcs-coding-standard-installer"
   },
   "require-dev": {
-      "phpunit/phpunit": "4.1.*"
+      "phpunit/phpunit": "~4.1"
   },
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,11 @@
       "name": "CakePHP Community",
       "homepage": "https://github.com/cakephp/cakephp-codesniffer/graphs/contributors"
     }
-  ]
+  ],
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/loadsys/composer-plugins.git"
+		}
+	]
 }

--- a/composer.json
+++ b/composer.json
@@ -30,16 +30,5 @@
       "name": "CakePHP Community",
       "homepage": "https://github.com/cakephp/cakephp-codesniffer/graphs/contributors"
     }
-  ],
-    "scripts": {
-        "post-install-cmd": [
-            "Loadsys\\Composer\\PhpCodesniffer\\CodingStandardHook::postInstall"
-        ],
-        "post-update-cmd": [
-            "Loadsys\\Composer\\PhpCodesniffer\\CodingStandardHook::postInstall"
-        ],
-        "pre-package-uninstall": [
-            "Loadsys\\Composer\\PhpCodesniffer\\CodingStandardHook::prePackageUninstall"
-        ]
-    }
+  ]
 }

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,15 @@
       "homepage": "https://github.com/cakephp/cakephp-codesniffer/graphs/contributors"
     }
   ],
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/loadsys/composer-plugins.git"
-		}
-	]
+    "scripts": {
+        "post-install-cmd": [
+            "Loadsys\\Composer\\PhpCodesniffer\\CodingStandardHook::postInstall"
+        ],
+        "post-update-cmd": [
+            "Loadsys\\Composer\\PhpCodesniffer\\CodingStandardHook::postInstall"
+        ],
+        "pre-package-uninstall": [
+            "Loadsys\\Composer\\PhpCodesniffer\\CodingStandardHook::prePackageUninstall"
+        ]
+    }
 }

--- a/snifftests/TestHelper.php
+++ b/snifftests/TestHelper.php
@@ -99,6 +99,7 @@ class TestHelper {
 		return $result;
 	}
 
+	//@TODO: Add a doc block. Sheesh.
 	public function sniffList() {
 		if (!class_exists('PHP_CodeSniffer')) {
 			$composerInstall = dirname(dirname(dirname(__FILE__))) . '/vendor/squizlabs/php_codesniffer/CodeSniffer.php';

--- a/snifftests/TestHelper.php
+++ b/snifftests/TestHelper.php
@@ -99,7 +99,16 @@ class TestHelper {
 		return $result;
 	}
 
-	//@TODO: Add a doc block. Sheesh.
+	/**
+	 * Asks the phpcs runtime for a list of code sniffs it knows about.
+	 *
+	 * Returns an array of `Vendor.Sniff.Rule` elements that match those
+	 * returned by `phpcs -s`. Used as a "meta" test in LoadsysStandardTest
+	 * to check which sniffs are covered by the sample files and which
+	 * aren't.
+	 *
+	 * @return array Comprehensive list of code sniffs the phpcs runtime knows about.
+	 */
 	public function sniffList() {
 		if (!class_exists('PHP_CodeSniffer')) {
 			$composerInstall = dirname(dirname(dirname(__FILE__))) . '/vendor/squizlabs/php_codesniffer/CodeSniffer.php';


### PR DESCRIPTION
Converts this packagist package to use a new `phpcs-coding-standard` type, which works with the `loadsys/composer-plugins` package to automatically copy coding standard folders into the correct directory for phpcs to use them. This PR should **not** be merged until loadsys/composer-plugins#4 is merged and `loadsys/composer-plugins` is available on Packagist (the Travis builds in this PR will continue to fail until that time.)