### PR TITLE
F/backport tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,17 @@ tags
 
 /vendor/
 /composer.lock
+
+# OS X
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+.Spotlight-V100
+.Trashes
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - vendor/bin/phpcs --config-set installed_paths vendor/cakephp/cakephp-codesniffer
 
 script:
+  - vendor/bin/phpcs -ps --standard=snifftests/sniff_class_rules.xml Loadsys/
   - vendor/bin/phpunit
 
 notifications:

--- a/Loadsys/Sniffs/Array/ArraySniff.php
+++ b/Loadsys/Sniffs/Array/ArraySniff.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * CodingStandard_Sniffs_Array_ArraySniff.
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package PHP_CodeSniffer
+ * @author Peter Philipp <peter.philipp@cando-image.com>
+ * @author Alexander Obuhovich <aik.bold@gmail.com>
+ * @license https://github.com/aik099/CodingStandard/blob/master/LICENSE BSD 3-Clause
+ * @link https://github.com/aik099/CodingStandard
+ */
+
+//@TODO: Make this pass our own sniffs.
+// namespace Loadsys\Sniffs\Array;
+//
+// use \PHP_CodeSniffer_Sniff;
+// use \ReflectionClass;
+// use \ReflectionException;
+
+/**
+ * CodingStandard_Sniffs_Array_ArraySniff.
+ *
+ * Checks if the array's are styled in the Drupal way.
+ * - Comma after the last array element
+ *
+ * Modified to check short array `[]` syntax. - beporter@users.sourceforge.net 2016-02-02
+ *
+ * @category PHP
+ * @package PHP_CodeSniffer
+ * @author Peter Philipp <peter.philipp@cando-image.com>
+ * @author Alexander Obuhovich <aik.bold@gmail.com>
+ * @license https://github.com/aik099/CodingStandard/blob/master/LICENSE BSD 3-Clause
+ * @link https://github.com/aik099/CodingStandard
+ */
+class Loadsys_Sniffs_Array_ArraySniff implements PHP_CodeSniffer_Sniff {
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return int[]
+	 */
+	public function register() {
+		return [T_OPEN_SHORT_ARRAY];
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+	 * @return void
+	 */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$arrayStart = $tokens[$stackPtr]['bracket_opener'];
+		$arrayEnd = $tokens[$arrayStart]['bracket_closer'];
+
+		// Check for empty arrays.
+		$content = $phpcsFile->findNext([T_WHITESPACE], ($arrayStart + 1), ($arrayEnd + 1), true);
+		if ($content === $arrayEnd) {
+			// Empty array, but if the brackets aren't together, there's a problem.
+			if (($arrayEnd - $arrayStart) !== 1) {
+				$error = 'Empty array declaration must have no space between the brackets.';
+				$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceInEmptyArray');
+				if ($fix === true) {
+					$phpcsFile->fixer->beginChangeset();
+
+					for ($i = ($arrayStart + 1); $i < $arrayEnd; $i++) {
+						$phpcsFile->fixer->replaceToken($i, '');
+					}
+
+					$phpcsFile->fixer->endChangeset();
+				}
+
+				// We can return here because there is nothing else to check. All code
+				// below can assume that the array is not empty.
+				return;
+			}
+		}
+
+		$lastItem = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($arrayEnd - 1), $stackPtr, true);
+
+		// Empty array.
+		if ($lastItem === $arrayStart) {
+			return;
+		}
+
+		// Inline array.
+		$isInlineArray = $tokens[$arrayStart]['line'] === $tokens[$arrayEnd]['line'];
+
+		// Check if the last item in a multiline array has a "closing" comma.
+		if ($tokens[$lastItem]['code'] !== T_COMMA && $isInlineArray === false) {
+			$error = 'A comma must follow the last multiline array item.';
+			$fix = $phpcsFile->addFixableError($error, $lastItem, 'NoLastComma');
+			if ($fix === true) {
+				$phpcsFile->fixer->beginChangeset();
+				$phpcsFile->fixer->addContent($lastItem, ',');
+				$phpcsFile->fixer->endChangeset();
+			}
+
+			return;
+		}
+
+		if ($isInlineArray === true) {
+			if ($tokens[$lastItem]['code'] === T_COMMA) {
+				$error = 'Comma not allowed after last value in single-line array declaration';
+				$fix = $phpcsFile->addFixableWarning($error, $lastItem, 'LastComma');
+				if ($fix === true) {
+					$phpcsFile->fixer->beginChangeset();
+					$phpcsFile->fixer->replaceToken($lastItem, '');
+					$phpcsFile->fixer->endChangeset();
+				}
+
+				return;
+			}
+
+			// Inline array must not have spaces within brackets.
+			if ($content !== ($arrayStart + 1)) {
+				$error = 'Space found after opening bracket of array';
+				$fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterOpen');
+				if ($fix === true) {
+					$phpcsFile->fixer->beginChangeset();
+
+					for ($i = ($arrayStart + 1); $i < $content; $i++) {
+						$phpcsFile->fixer->replaceToken($i, '');
+					}
+
+					$phpcsFile->fixer->endChangeset();
+				}
+			}
+
+			if ($lastItem !== ($arrayEnd - 1)) {
+				$error = 'Space found before closing bracket of array';
+				$fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceBeforeClose');
+				if ($fix === true) {
+					$phpcsFile->fixer->beginChangeset();
+
+					for ($i = ($lastItem + 1); $i < $arrayEnd; $i++) {
+						$phpcsFile->fixer->replaceToken($i, '');
+					}
+
+					$phpcsFile->fixer->endChangeset();
+				}
+			}
+		}
+	}
+}

--- a/Loadsys/Sniffs/Array/ArraySniff.php
+++ b/Loadsys/Sniffs/Array/ArraySniff.php
@@ -12,13 +12,6 @@
  * @link https://github.com/aik099/CodingStandard
  */
 
-//@TODO: Make this pass our own sniffs.
-// namespace Loadsys\Sniffs\Array;
-//
-// use \PHP_CodeSniffer_Sniff;
-// use \ReflectionClass;
-// use \ReflectionException;
-
 /**
  * CodingStandard_Sniffs_Array_ArraySniff.
  *
@@ -62,7 +55,7 @@ class Loadsys_Sniffs_Array_ArraySniff implements PHP_CodeSniffer_Sniff {
 			// Empty array, but if the brackets aren't together, there's a problem.
 			if (($arrayEnd - $arrayStart) !== 1) {
 				$error = 'Empty array declaration must have no space between the brackets.';
-				$fix   = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceInEmptyArray');
+				$fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceInEmptyArray');
 				if ($fix === true) {
 					$phpcsFile->fixer->beginChangeset();
 

--- a/Loadsys/Sniffs/NamingConventions/ValidClassBracketsSniff.php
+++ b/Loadsys/Sniffs/NamingConventions/ValidClassBracketsSniff.php
@@ -35,7 +35,7 @@ class Loadsys_Sniffs_NamingConventions_ValidClassBracketsSniff implements PHP_Co
 	 * Processes this test, when one of its tokens is encountered.
 	 *
 	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-	 * @param integer $stackPtr  The position of the current token in the stack passed in $tokens.
+	 * @param int $stackPtr  The position of the current token in the stack passed in $tokens.
 	 * @return void
 	 */
 	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {

--- a/Loadsys/Sniffs/NamingConventions/ValidPrivateProtectedFunctionNameSniff.php
+++ b/Loadsys/Sniffs/NamingConventions/ValidPrivateProtectedFunctionNameSniff.php
@@ -14,13 +14,6 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-//@TODO: Make this pass our own sniffs.
-// namespace Loadsys\Sniffs\NamingConventions;
-//
-// use \PHP_CodeSniffer_Standards_AbstractScopeSniff;
-// use \ReflectionClass;
-// use \ReflectionException;
-
 /**
  * Ensures method names are correct depending on whether they are public
  * or private, and that functions are named correctly.

--- a/Loadsys/ruleset.xml
+++ b/Loadsys/ruleset.xml
@@ -32,6 +32,20 @@
 	</rule>
 
 	<!--
+	Reduce the severity of TO DO marker warnings to allow them to be more
+	easily suppressed during normal developer runs, but still included in
+	Travis builds (via coordination with the `codesniffer-run` script from
+	the CakePHP-Shell-Scripts project and manipulation of the
+	`- -warning-severity=n` command line option.)
+	-->
+	<rule ref="Generic.Commenting.Todo.CommentFound">
+		<severity>3</severity>
+	</rule>
+	<rule ref="Generic.Commenting.Todo.TaskFound">
+		<severity>3</severity>
+	</rule>
+
+	<!--
 	Enforce "the opposite" of the disabled PSR-2/CakePHP rules above. In
 	other words; it's not enough to DISable the enforcement of spaces for
 	indenting, we must also ENable enforcement of tabs for indenting.

--- a/Loadsys/ruleset.xml
+++ b/Loadsys/ruleset.xml
@@ -6,7 +6,7 @@
 	<exclude-pattern>*/config/*.ini.php</exclude-pattern>
 	<exclude-pattern>/*/tmp/</exclude-pattern>
 
-	<!-- Include most CakePHP (and PSR-2/PSR-1, by extension) rules. -->
+	<!-- Include most CakePHP rules (and PSR-2/PSR-1, by extension). -->
 	<rule ref="CakePHP">
 		<!-- Disable enforcing opening class brace on same line -->
 		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
@@ -51,6 +51,12 @@
 
 	<rule ref="Loadsys.NamingConventions.ValidPrivateProtectedVariableName.ProtectedUnderscore">
 		<type>warning</type>
+
+		<!--
+		Entity classes MUST define override methods that do not follow
+		camelCasing so don't make those "errors" at all.
+		-->
+		<exclude-pattern>src/Model/Entity/*</exclude-pattern>
 	</rule>
 
 	<rule ref="Loadsys.NamingConventions.ValidPrivateProtectedVariableName.PrivateWithUnderscore">
@@ -68,6 +74,17 @@
 
 	<rule ref="Loadsys.NamingConventions.ValidPrivateProtectedFunctionName.ProtectedWithUnderscore">
 		<type>warning</type>
+
+		<!--
+		Entity classes MUST define override properties that do not follow
+		camelCasing so don't make those "errors" at all.
+		-->
+		<exclude-pattern>src/Model/Entity/*</exclude-pattern>
+
+		<!--
+		Form classes MUST used underscored method names.
+		-->
+		<exclude-pattern>src/Form/*</exclude-pattern>
 	</rule>
 
 	<rule ref="Loadsys.NamingConventions.ValidPrivateProtectedFunctionName.PrivateWithUnderscore">
@@ -77,7 +94,7 @@
 	<!--
 	Phinx migration files define classes, but can not be namespaced
 	(otherwise Phinx can't construct them by guessing the class name from
-	the filename.
+	the filename.)
 	Ref: https://github.com/robmorgan/phinx/blob/695ce926c402e4c75ec76ec0a11e027824ff05ea/src/Phinx/Migration/Manager.php#L403
 	So relax the namespacing rules on the config/Migrations folder.
 	-->
@@ -99,54 +116,21 @@
 
 
 	<!--
-	@TODO: These sniffs need to be reviewed to see if they duplicate
-	coverage already provided. The ones that should be kept need
-	tests written for them.
+	Pull in additional rules not previously covered by parent rulesets
+	(or explicitly excluded by them).
 	-->
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
-	<rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
-	<rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
-	<rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
-	<rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
-	<rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
 	<rule ref="Generic.Commenting.Fixme"/>
-	<rule ref="Generic.Commenting.Todo"/>
-	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
-	<rule ref="Generic.Formatting.NoSpaceAfterCast"/>
 	<rule ref="Generic.Metrics.NestingLevel"/>
-	<rule ref="Generic.NamingConventions.CamelCapsFunctionName"/>
 	<rule ref="Generic.NamingConventions.ConstructorName"/>
-	<rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
-	<rule ref="Generic.PHP.DeprecatedFunctions"/>
-	<rule ref="Generic.PHP.ForbiddenFunctions"/>
-	<rule ref="Generic.PHP.LowerCaseConstant"/>
-	<rule ref="Generic.PHP.NoSilencedErrors"/>
 	<rule ref="Generic.Strings.UnnecessaryStringConcat"/>
 	<rule ref="MySource.PHP.EvalObjectFactory"/>
-	<rule ref="PEAR.ControlStructures.ControlSignature"/>
 	<rule ref="PEAR.ControlStructures.MultiLineCondition"/>
-	<rule ref="PEAR.NamingConventions.ValidClassName"/>
-	<rule ref="PEAR.NamingConventions.ValidFunctionName"/>
-	<rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
-	<rule ref="Squiz.Classes.LowercaseClassKeywords"/>
-	<rule ref="Squiz.Commenting.DocCommentAlignment"/>
-	<rule ref="Squiz.Operators.ValidLogicalOperators"/>
 	<rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
 	<rule ref="Squiz.PHP.DisallowObEndFlush"/>
-	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
 	<rule ref="Squiz.PHP.Eval"/>
 	<rule ref="Squiz.PHP.LowercasePHPFunctions"/>
-	<rule ref="Squiz.PHP.NonExecutableCode"/>
-	<rule ref="Squiz.Scope.MemberVarScope"/>
-	<rule ref="Squiz.Scope.MethodScope"/>
-	<rule ref="Squiz.Scope.StaticThisUsage"/>
-	<rule ref="Squiz.WhiteSpace.CastSpacing"/>
 	<rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
 	<rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
-	<rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
-	<rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
-	<rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
-	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
 
 	<!-- All rules in ./Sniffs are included automatically -->
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Since we inherit from these rulesets, it's nice to have links to them handy:
 
 ### Running codesniffs on the Loadsys-defined Sniff classes
 
-`vendor/bin/phpcs -p --standard=./Loadsys Loadsys/`
+`vendor/bin/phpcs -ps --standard=snifftests/sniff_class_rules.xml Loadsys/`
+
+This custom ruleset relaxes a few of our normal rules to accommodate shortcomings in PHPCS's requirements for Sniff classes themselves (such as not supporting namepspaces or CamelCased class names.) The ruleset will run the entire Loadsys standard with those rules excluded.
 
 
 ### Reviewing the rules included in the standard

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Other items that are inherited but worth pointing out anyway:
 
 * Namespaces are mandatory for classes.
 * Short array syntax is mandatory.
-* Final commas in multi-line arrays are mandatory (soon).
+* Final commas in multi-line arrays are mandatory.
 
 
 ## Installation

--- a/snifftests/files/closures_pass.php
+++ b/snifftests/files/closures_pass.php
@@ -9,5 +9,5 @@ $passArray = [
 	'hello' => 'Beakman',
 	'whatsup' => function ($one, $two) use ($derp) {
 		echo $one . $two;
-	}
+	},
 ];

--- a/snifftests/files/must_not/array_multiline_trailing_comma.php
+++ b/snifftests/files/must_not/array_multiline_trailing_comma.php
@@ -1,5 +1,4 @@
-<?php //~
-//To Do: Find or write a sniff to catch this. For now, allow this test to pass.
+<?php //~Loadsys.Array.Array.NoLastComma
 $a = [
 	1,
 	[

--- a/snifftests/sniff_class_rules.xml
+++ b/snifftests/sniff_class_rules.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="SniffClassRules">
+	<description>Custom rules for Sniff classes in the Loadsys coding standard.</description>
+
+	<!--
+	Soften some of our normal rules since PHPCS can't handle Sniffs with
+	 namespaces and doesn't use camelCased class names.
+	 -->
+	<rule ref="../Loadsys/ruleset.xml">
+		<exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
+
+		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+	</rule>
+</ruleset>


### PR DESCRIPTION
* Adds a sniff to enforce trailing commas on multi-line arrays. Closes #40 
* Removes unnecessary rule duplication from `Loadsys/ruleset.xml`. Closes #41 
* Turns on code sniffs in Travis builds for the `Loadsys/Sniffs/` classes themselves by using a custom ruleset that likewise suppresses some of our normal rules that conflict with PHPCS requirements (not being able to use namespaces or CamelCased class names.) Closes #42 
* Imports some relaxed ruleset tweaks from real-world use to reduce noise from Cake 3 classes that "break the rules" (like Entity classes using `public $_accessible;`)
* Reduces the severity of `Todo` markers to facilitate suppressing **only** those more easily via the `codesniffer-run` wrapper script in the CakePHP-Shell-Scripts repo.
