### PR TITLE
F/enforce class declarations

### DIFF
--- a/Loadsys/Sniffs/Namespaces/ClassesMustBeImportedSniff.php
+++ b/Loadsys/Sniffs/Namespaces/ClassesMustBeImportedSniff.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Makes it illegal to call a namespaces class using its fully qualified name.
+ * (Instead all used classes must be imported at the top of the file.)
+ *
+ * @link https://github.com/WoltLab/WCF/blob/a3bdb99/CodeSniff/WCF/Sniffs/Namespaces/ClassMustBeImportedSniff.php
+ */
+
+/**
+ * Loadsys_Sniffs_Namespaces_ClassesMustBeImportedSniff
+ */
+class Loadsys_Sniffs_Namespaces_ClassesMustBeImportedSniff implements PHP_CodeSniffer_Sniff {
+	/**
+	 * Return an array of tokens for which this sniff wants to engage.
+	 *
+	 * @return array List of PHP tokens this sniff cares about.
+	 */
+	public function register() {
+		return [T_NS_SEPARATOR];
+	}
+
+	/**
+	 * Process the sniff. Will be engaged when one of the tokens from ::register() is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile An instance of the current source file being scanned.
+	 * @param int $stackPtr The position of the encountered token in the provided file.
+	 * @return void
+	 */
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Nothing to do if the file is already in the global namespace.
+		if ($phpcsFile->findPrevious(T_NAMESPACE, $stackPtr) === false) {
+			return;
+		}
+
+		// Only proceed with checking the matched namespaced string if is not part of a `namespace Vendor\Foo;` or a `use Vendor\Bar as Baz;` statement.
+		if ($phpcsFile->findPrevious([T_NAMESPACE, T_USE], ($stackPtr - 1), null, false, null, true) === false) {
+			$nextNonClassSegment = $phpcsFile->findNext([T_NS_SEPARATOR, T_STRING], ($stackPtr + 1), null, true);
+			$lastNsSeperator = $phpcsFile->findPrevious(T_NS_SEPARATOR, $nextNonClassSegment);
+
+			// Only report for the last backslash matched in a single namespace string. (This sniff will trigger on each slash from `new \Some\Vendor\Lib();`, so this makes sure we don't report 3 errors for that same statement.)
+			if ($lastNsSeperator === $stackPtr) {
+				$start = $phpcsFile->findPrevious([T_NS_SEPARATOR, T_STRING], ($stackPtr - 1), null, true) + 1;
+				$end = $phpcsFile->findNext([T_NS_SEPARATOR, T_STRING], ($start + 1), null, true);
+
+				$class = '';
+				for ($i = $start; $i < $end; $i++) {
+					$class .= $tokens[$i]['content'];
+				}
+
+				$tClass = $phpcsFile->findPrevious(T_CLASS, ($stackPtr - 1));
+
+				// Check if the code is attempting to extend a class with the same name.
+				if ($tClass !== false) {
+					$newClass = $phpcsFile->findNext(T_STRING, $tClass);
+					if ($tokens[$newClass]['content'] == $tokens[$end - 1]['content']) {
+						return;
+					}
+
+					$err = 'Namespaced class (%s) must be imported before use.';
+					$data = [$class];
+					$phpcsFile->addError($err, $stackPtr, 'ClassMustBeImported', $data);
+				}
+			}
+		}
+	}
+}

--- a/Loadsys/ruleset.xml
+++ b/Loadsys/ruleset.xml
@@ -29,6 +29,15 @@
 
 		<!-- Exclude PEAR style control structures like `if (...)\n{\n` -->
 		<exclude name="PEAR.ControlStructures.ControlSignature"/>
+
+		<!--
+		DON'T exclude either the generic comma-spacing sniff (because it
+		provides fixers) or Cake's (since it captures more).
+		-->
+		<!--
+		<exclude name="Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeComma"/>
+		<exclude name="CakePHP.WhiteSpace.CommaSpacing"/>
+		-->
 	</rule>
 
 	<!--

--- a/README.md
+++ b/README.md
@@ -18,12 +18,21 @@ This ruleset is basically [PSR-2](http://www.php-fig.org/psr/psr-2/) with the fo
 
 * Tabs are used for indenting instead of spaces. 1 character is better than 4. The other arguments for "fine grained alignment" are a failure of editing tools, not the tab character itself. Resorting to spaces is the wrong solution to the problem. _(See [Elastic Tabstops](http://nickgravgaard.com/elastic-tabstops/).)_
 * Opening braces universally go on the same line as their block opener. This applies to classes, functions, methods and all control structures. We prefer a single consistent bracing rule.
+* Final commas in multi-line arrays are mandatory. This makes diffs cleaner and reduces mistakes when re-ordering lists.
+* All classes must be declared before use at the top of the file.
+	```php
+	$var = new \DateTime(); // invalid
+	$var = new \Vendor\Lib(); // invalid
+	$var = new Local\SubClass(); // invalid
+	//---
+	use \DateTime
+	$var = new DateTime(); // valid
+	```
 
 Other items that are inherited but worth pointing out anyway:
 
 * Namespaces are mandatory for classes.
 * Short array syntax is mandatory.
-* Final commas in multi-line arrays are mandatory.
 
 
 ## Installation
@@ -147,9 +156,25 @@ Positive verification tests are especially important when making modifications t
 
 ### Manually reviewing tests/rules
 
-The output from `find snifftests/files -type f -name '*pass.php' -exec vendor/bin/phpcs -p --standard=./Loadsys {} +` should always pass all sniffs, since these are all of the sample files suffixed with `pass.php`.
+To test a single sample file, run:
 
-Every file listed in `find snifftests/files -type f -name '*.php' ! -name '*pass.php' -exec vendor/bin/phpcs -p --standard=./Loadsys {} +` should throw at least one warning or error each. (Pay attention to any `.`s in the initial progress indicator since that indicates a fully-passing file that should be failing something!) The errors listed will need to be verified by hand that they correctly match the errors that particular file _should_ be triggering.
+```php
+$ vendor/bin/phpcs -ps --standard=./Loadsys snifftests/files/sample_file_name.php
+```
+
+To confirm that all test files that **should** pass **do** pass, run:
+
+```php
+$ find snifftests/files -type f -name '*pass.php' -exec vendor/bin/phpcs -p --standard=./Loadsys {} +
+```
+
+To confirm that all files that should fail, do fail, run:
+
+```php
+$ find snifftests/files -type f -name '*.php' ! -name '*pass.php' -exec vendor/bin/phpcs -p --standard=./Loadsys {} +
+```
+
+Every file listed in should throw at least one warning or error each. (Pay attention to any `.`s in the initial progress indicator since that indicates a fully-passing file that should be failing something!) The errors listed will need to be verified by hand that they correctly match the errors that particular file _should_ be triggering.
 
 
 ## License
@@ -159,4 +184,4 @@ Every file listed in `find snifftests/files -type f -name '*.php' ! -name '*pass
 
 ## Copyright
 
-[Loadsys Web Strategies](http://www.loadsys.com) 2015
+[Loadsys Web Strategies](http://www.loadsys.com) 2016

--- a/snifftests/files/Loadsys/throws_pass.php
+++ b/snifftests/files/Loadsys/throws_pass.php
@@ -4,6 +4,7 @@ namespace Loadsys;
 
 use Other\Crap;
 use Other\Error as OtherError;
+use \Exception;
 
 class Throws {
 
@@ -26,7 +27,7 @@ class Throws {
 			case 3:
 				throw new Crap();
 			default:
-				throw new \Exception();
+				throw new Exception();
 		}
 	}
 }

--- a/snifftests/files/Loadsys/throws_pass.php
+++ b/snifftests/files/Loadsys/throws_pass.php
@@ -22,10 +22,8 @@ class Throws {
 			case 1:
 				throw new Boom();
 			case 2:
-				throw new Error\Boom();
+				throw new OtherError();
 			case 3:
-				throw new OtherError\Issue();
-			case 4:
 				throw new Crap();
 			default:
 				throw new \Exception();

--- a/snifftests/files/control_structure_indentation.php
+++ b/snifftests/files/control_structure_indentation.php
@@ -1,4 +1,4 @@
-<?php //~Generic.WhiteSpace.ScopeIndent.IncorrectExact, Squiz.WhiteSpace.ScopeClosingBrace.Indent, CakePHP.WhiteSpace.ScopeClosingBrace.Indent
+<?php //~Generic.WhiteSpace.ScopeIndent.IncorrectExact, Squiz.WhiteSpace.ScopeClosingBrace.Indent
 if ($value) {
 	$thing = 'test';
 	} // Error: Incorrect indenting.

--- a/snifftests/files/function_comments_pass.php
+++ b/snifftests/files/function_comments_pass.php
@@ -2,6 +2,8 @@
 
 namespace Foo;
 
+use \Exception;
+
 class Foo {
 
 	/**
@@ -12,7 +14,7 @@ class Foo {
 	 * @throws \Exception Bad things happen.
 	 */
 	public function doThing($foo) {
-		throw new \Exception('yikes');
+		throw new Exception('yikes');
 	}
 
 	/**

--- a/snifftests/files/must/namespaces_inline_fqdns_pass.php
+++ b/snifftests/files/must/namespaces_inline_fqdns_pass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Lib;
+
+// Must declare all namespaced classes used in the file.
+use \Vendor\Group\Library;
+
+class Foo {
+	/**
+	 * Build a thing.
+	 */
+	public function __construct() {
+		$a = new Library(); // Local use of classes must not contain namespaces.
+		$a->doSomething();
+	}
+}

--- a/snifftests/files/must_not/namespaces_inline_fqdns.php
+++ b/snifftests/files/must_not/namespaces_inline_fqdns.php
@@ -1,0 +1,18 @@
+<?php //~Loadsys.Namespaces.ClassesMustBeImported.ClassMustBeImported
+
+namespace App\Lib;
+
+use Not\The\Library\Below;
+
+class Foo {
+	/**
+	 * Build a thing.
+	 */
+	public function __construct() {
+		// Do not use fully-qualified or partially qualified namespaces
+		// inline. (Declare them with `use` at the top of the file.)
+		$a = new \Vendor\Group\Library();
+		$b = new \DateTime();
+		$c = new vendor\NotImported();
+	}
+}

--- a/snifftests/files/whitespace_comma_before_in_function.php
+++ b/snifftests/files/whitespace_comma_before_in_function.php
@@ -1,2 +1,2 @@
 <?php //~Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeComma, CakePHP.WhiteSpace.CommaSpacing
-echo implode('' , array_fill(3)); // Error: Comma in function call followed by whitespace.
+echo implode('' , array_fill(3)); // Error: Comma in function call preceded by whitespace.


### PR DESCRIPTION
Implements a new sniff that requires all used classes to be imported first. Refer to the following examples:

```php
<?php
// invalid:
$var = new \DateTime();
$var = new \Vendor\Lib();
$var = new Local\SubClass();
```

```php
<?php
// valid
use Vendor\Lib;
use \DateTime;

//...

$var = new DateTime();
$var = new Lib();
```