### PR TITLE
Exlude config/Seeds from sniffs

### DIFF
--- a/Loadsys/Sniffs/NamingConventions/ValidClassBracketsSniff.php
+++ b/Loadsys/Sniffs/NamingConventions/ValidClassBracketsSniff.php
@@ -45,6 +45,7 @@ class Loadsys_Sniffs_NamingConventions_ValidClassBracketsSniff implements PHP_Co
 		if ($tokens[$found - 1]['code'] != T_WHITESPACE) {
 			$error = 'Expected 1 space after class declaration, found 0';
 			$phpcsFile->addError($error, $found - 1, 'InvalidSpacing', []);
+
 			return;
 		} elseif ($tokens[$found - 1]['content'] != " ") {
 			$error = 'Expected 1 space before curly opening bracket';

--- a/Loadsys/Sniffs/NamingConventions/ValidPrivateProtectedFunctionNameSniff.php
+++ b/Loadsys/Sniffs/NamingConventions/ValidPrivateProtectedFunctionNameSniff.php
@@ -99,6 +99,7 @@ class Loadsys_Sniffs_NamingConventions_ValidPrivateProtectedFunctionNameSniff ex
 			if ($methodName[0] === '_') {
 				$error = 'Public method name "%s" must not be prefixed with underscore';
 				$phpcsFile->addError($error, $stackPtr, 'PublicWithUnderscore', $errorData);
+
 				return;
 			}
 
@@ -120,12 +121,14 @@ class Loadsys_Sniffs_NamingConventions_ValidPrivateProtectedFunctionNameSniff ex
 			if ($methodName[0] === '_' || substr($methodName, 0, 2) === '__') {
 				$error = 'Private method name "%s" must not be prefixed with underscores';
 				$phpcsFile->addError($error, $stackPtr, 'PrivateWithUnderscore', $errorData);
+
 				return;
 			}
 		} else {
 			if ($methodName[0] === '_' || substr($methodName, 0, 2) === '__') {
 				$error = 'Protected method name "%s" must not be prefixed with underscores';
 				$phpcsFile->addError($error, $stackPtr, 'ProtectedWithUnderscore', $errorData);
+
 				return;
 			}
 		}

--- a/Loadsys/Sniffs/NamingConventions/ValidPrivateProtectedVariableNameSniff.php
+++ b/Loadsys/Sniffs/NamingConventions/ValidPrivateProtectedVariableNameSniff.php
@@ -106,6 +106,7 @@ class Loadsys_Sniffs_NamingConventions_ValidPrivateProtectedVariableNameSniff ex
 				$error = 'Public member variable "%s" must not contain a leading underscore';
 				$data = [$varName];
 				$phpcsFile->addError($error, $stackPtr, 'PublicHasUnderscore', $data);
+
 				return;
 			}
 		} elseif ($private === true) {
@@ -113,6 +114,7 @@ class Loadsys_Sniffs_NamingConventions_ValidPrivateProtectedVariableNameSniff ex
 				$error = 'Private member variable "%s" must not contain two leading underscores';
 				$data = [$varName];
 				$phpcsFile->addError($error, $stackPtr, 'PrivateWithUnderscore', $data);
+
 				return;
 			}
 
@@ -127,6 +129,7 @@ class Loadsys_Sniffs_NamingConventions_ValidPrivateProtectedVariableNameSniff ex
 				$error = 'Protected member variable "%s" must not contain a leading underscore';
 				$data = [$varName];
 				$phpcsFile->addError($error, $stackPtr, 'ProtectedUnderscore', $data);
+
 				return;
 			}
 		}

--- a/Loadsys/ruleset.xml
+++ b/Loadsys/ruleset.xml
@@ -115,14 +115,15 @@
 	</rule>
 
 	<!--
-	Phinx migration files define classes, but can not be namespaced
+	Phinx migration and seeds files define classes, but can not be namespaced
 	(otherwise Phinx can't construct them by guessing the class name from
 	the filename.)
 	Ref: https://github.com/robmorgan/phinx/blob/695ce926c402e4c75ec76ec0a11e027824ff05ea/src/Phinx/Migration/Manager.php#L403
-	So relax the namespacing rules on the config/Migrations folder.
+    So relax the namespacing rules on the config/Migrations and config/Seeds folder.
 	-->
 	<rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
 		<exclude-pattern>*/config/Migrations/*</exclude-pattern>
+		<exclude-pattern>*/config/Seeds/*</exclude-pattern>
 	</rule>
 
 


### PR DESCRIPTION
Similar to `config/Migrations`, `config/Seeds` can not be namespaced either and therefore should be excluded from the rule set.